### PR TITLE
GUAC-4961 Change how reference image is found

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -201,9 +201,14 @@ public func verifySnapshot<Value, Format>(
         let testName = sanitizePathComponent(testName)
 
         // Check the bundle for the resource first, then the file system
-        let thisBundle = Bundle(for: CleanCounterBetweenTestCases.self)
-        let resourcePath = thisBundle.path(forResource: "\(testName).\(identifier)",  ofType: snapshotting.pathExtension)
-        var snapshotFileUrlCandidate = resourcePath.map({ URL(fileURLWithPath: $0) })
+        // But, if we're recording, don't bother checking the bundle, since we aren't comparing it to anything, and
+        // want the new file to be generated in the source directory, not the bundle.
+        var snapshotFileUrlCandidate: URL?
+        if !recording {
+            let thisBundle = Bundle(for: CleanCounterBetweenTestCases.self)
+            let resourcePath = thisBundle.path(forResource: "\(testName).\(identifier)",  ofType: snapshotting.pathExtension)
+            snapshotFileUrlCandidate = resourcePath.map({ URL(fileURLWithPath: $0) })
+        }
         if snapshotFileUrlCandidate == nil {
             snapshotFileUrlCandidate = snapshotDirectoryUrl
                 .appendingPathComponent("\(testName).\(identifier)")


### PR DESCRIPTION
If recording, don't look for the reference image in the bundle, since this sets the file name for generation later. Instead, look for a local copy of the file (since we won't be recording tests in CI), so that's where the new file gets generated.
